### PR TITLE
Added [NotMapped] attribute to public Properties

### DIFF
--- a/Library/Validation/ValidatableModelBase.cs
+++ b/Library/Validation/ValidatableModelBase.cs
@@ -7,6 +7,7 @@ using Newtonsoft.Json;
 using Template10.Controls.Validation;
 using Template10.Interfaces.Validation;
 using Windows.Foundation.Collections;
+using System.ComponentModel.DataAnnotations.Schema;
 
 namespace Template10.Validation
 {
@@ -83,20 +84,25 @@ namespace Template10.Validation
             Validate();
         }
 
+        [NotMapped]
         [JsonIgnore]
         public ObservableDictionary<string, IProperty> Properties { get; }
             = new ObservableDictionary<string, IProperty>();
 
+        [NotMapped]
         [JsonIgnore]
         public ObservableCollection<string> Errors { get; }
             = new ObservableCollection<string>();
 
+        [NotMapped]
         [JsonIgnore]
         public Action<IValidatableModel> Validator { set; get; }
 
+        [NotMapped]
         [JsonIgnore]
         public bool IsValid => !Errors.Any();
 
+        [NotMapped]
         [JsonIgnore]
         public bool IsDirty { get; }
 

--- a/Library/Validation/ValidatableModelBase.cs
+++ b/Library/Validation/ValidatableModelBase.cs
@@ -7,8 +7,6 @@ using Newtonsoft.Json;
 using Template10.Controls.Validation;
 using Template10.Interfaces.Validation;
 using Windows.Foundation.Collections;
-using System.ComponentModel.DataAnnotations;
-using System.ComponentModel.DataAnnotations.Schema;
 
 namespace Template10.Validation
 {
@@ -31,7 +29,6 @@ namespace Template10.Validation
 
         public event PropertyChangedEventHandler PropertyChanged;
 
-        
         protected T Read<T>([CallerMemberName]string propertyName = null)
         {
             if (!Properties.ContainsKey(propertyName))
@@ -52,7 +49,6 @@ namespace Template10.Validation
             }
         }
 
-        
         public bool Validate()
         {
             foreach (var property in Properties)
@@ -87,25 +83,20 @@ namespace Template10.Validation
             Validate();
         }
 
-        [NotMapped]
         [JsonIgnore]
         public ObservableDictionary<string, IProperty> Properties { get; }
             = new ObservableDictionary<string, IProperty>();
 
-        [NotMapped]
         [JsonIgnore]
         public ObservableCollection<string> Errors { get; }
             = new ObservableCollection<string>();
 
-        [NotMapped]
         [JsonIgnore]
         public Action<IValidatableModel> Validator { set; get; }
 
-        [NotMapped]
         [JsonIgnore]
         public bool IsValid => !Errors.Any();
 
-        [NotMapped]
         [JsonIgnore]
         public bool IsDirty { get; }
 

--- a/Library/Validation/ValidatableModelBase.cs
+++ b/Library/Validation/ValidatableModelBase.cs
@@ -7,6 +7,8 @@ using Newtonsoft.Json;
 using Template10.Controls.Validation;
 using Template10.Interfaces.Validation;
 using Windows.Foundation.Collections;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
 
 namespace Template10.Validation
 {
@@ -29,6 +31,7 @@ namespace Template10.Validation
 
         public event PropertyChangedEventHandler PropertyChanged;
 
+        
         protected T Read<T>([CallerMemberName]string propertyName = null)
         {
             if (!Properties.ContainsKey(propertyName))
@@ -49,6 +52,7 @@ namespace Template10.Validation
             }
         }
 
+        
         public bool Validate()
         {
             foreach (var property in Properties)
@@ -83,20 +87,25 @@ namespace Template10.Validation
             Validate();
         }
 
+        [NotMapped]
         [JsonIgnore]
         public ObservableDictionary<string, IProperty> Properties { get; }
             = new ObservableDictionary<string, IProperty>();
 
+        [NotMapped]
         [JsonIgnore]
         public ObservableCollection<string> Errors { get; }
             = new ObservableCollection<string>();
 
+        [NotMapped]
         [JsonIgnore]
         public Action<IValidatableModel> Validator { set; get; }
 
+        [NotMapped]
         [JsonIgnore]
         public bool IsValid => !Errors.Any();
 
+        [NotMapped]
         [JsonIgnore]
         public bool IsDirty { get; }
 

--- a/Library/project.json
+++ b/Library/project.json
@@ -1,7 +1,8 @@
 ﻿{
   "dependencies": {
     "Microsoft.NETCore.UniversalWindowsPlatform": "5.2.2",
-    "Newtonsoft.Json": "8.0.3"
+    "Newtonsoft.Json": "9.0.1"
+
   },
   "frameworks": {
     "uap10.0": {}

--- a/Library/project.json
+++ b/Library/project.json
@@ -1,8 +1,7 @@
 ﻿{
   "dependencies": {
     "Microsoft.NETCore.UniversalWindowsPlatform": "5.2.2",
-    "Newtonsoft.Json": "9.0.1"
-
+    "Newtonsoft.Json": "8.0.3"
   },
   "frameworks": {
     "uap10.0": {}

--- a/Sample/project.json
+++ b/Sample/project.json
@@ -3,7 +3,7 @@
     "Microsoft.NETCore.UniversalWindowsPlatform": "5.2.2",
     "Microsoft.Xaml.Behaviors.Uwp.Managed": "1.1.0",
     "Template10": "1.1.11",
-    "Template10-Validation": "1.0.0"
+    "Template10-Validation": "0.0.4-preview"
   },
   "frameworks": {
     "uap10.0": {}

--- a/Sample/project.json
+++ b/Sample/project.json
@@ -3,7 +3,7 @@
     "Microsoft.NETCore.UniversalWindowsPlatform": "5.2.2",
     "Microsoft.Xaml.Behaviors.Uwp.Managed": "1.1.0",
     "Template10": "1.1.11",
-    "Template10-Validation": "0.0.4-preview"
+    "Template10-Validation": "1.0.0"
   },
   "frameworks": {
     "uap10.0": {}


### PR DESCRIPTION
By adding [NotMapped] it prevents (EF/EFC for example from) the public properties that are inherited from ValidatibleModelBase be created in table of the class object which has validation requirements from input.  This had consequences of "ShadowProperties" and database creation issues associated with it.

the sample project.json was coincidentally updated to work with V1 of Validation lib.
